### PR TITLE
rem units and sizeRegex.lastIndex

### DIFF
--- a/lib/font-booster-fixer.js
+++ b/lib/font-booster-fixer.js
@@ -80,6 +80,7 @@
     }
 
     var sizeMatches = this.sizeRegex.exec(value);
+    this.sizeRegex.lastIndex = 0;
     if(sizeMatches) {
       value = (parseFloat(sizeMatches[1]) * this.factor) + sizeMatches[2] + sizeMatches[3];
     }

--- a/lib/font-booster-fixer.js
+++ b/lib/font-booster-fixer.js
@@ -32,7 +32,7 @@
      *
      * @type Array
      */
-    this.units = options.units || ['px', 'pt', 'pc', 'cm', 'mm', 'pc'];
+    this.units = options.units || ['px', 'pt', 'pc', 'cm', 'mm', 'pc', 'rem'];
 
     /**
      * List style attributes to be converted


### PR DESCRIPTION
- Add rem to default units (rem units are effected by font booster.)
- Reset sizeRegex.lastIndex After Exec Call (Prevent sizeRegex.exec(value) from missing values that need to be converted.)
